### PR TITLE
メッセージ送信機能実装（グループメッセージの表示）

### DIFF
--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -9,62 +9,8 @@
       .ChatMain__GroupInfo__rightbox--editbtn
         = link_to 'Edit', '#'
   .ChatMain__MessagesList
-    .ChatMain__MessagesList__box
-      .ChatMain__MessagesList__box__group
-        .ChatMain__MessagesList__box__group--name
-          %p sawa
-        .ChatMain__MessagesList__box__group--date
-          %p 2020/02/06(THU) 07:35:00
-      .ChatMain__MessagesList__box__message
-        %p おはよう！
-    .ChatMain__MessagesList__box
-      .ChatMain__MessagesList__box__group
-        .ChatMain__MessagesList__box__group--name
-          %p sawa
-        .ChatMain__MessagesList__box__group--date
-          %p 2020/02/06(THU) 07:35:00
-      .ChatMain__MessagesList__box__message
-        %p おはよう！2
-    .ChatMain__MessagesList__box
-      .ChatMain__MessagesList__box__group
-        .ChatMain__MessagesList__box__group--name
-          %p sawa
-        .ChatMain__MessagesList__box__group--date
-          %p 2020/02/06(THU) 07:35:00
-      .ChatMain__MessagesList__box__message
-        %p おはよう！3
-    .ChatMain__MessagesList__box
-      .ChatMain__MessagesList__box__group
-        .ChatMain__MessagesList__box__group--name
-          %p sawa
-        .ChatMain__MessagesList__box__group--date
-          %p 2020/02/06(THU) 07:35:00
-      .ChatMain__MessagesList__box__message
-        %p おはよう！4
-    .ChatMain__MessagesList__box
-      .ChatMain__MessagesList__box__group
-        .ChatMain__MessagesList__box__group--name
-          %p sawa
-        .ChatMain__MessagesList__box__group--date
-          %p 2020/02/06(THU) 07:35:00
-      .ChatMain__MessagesList__box__message
-        %p おはよう！5
-    .ChatMain__MessagesList__box
-      .ChatMain__MessagesList__box__group
-        .ChatMain__MessagesList__box__group--name
-          %p sawa
-        .ChatMain__MessagesList__box__group--date
-          %p 2020/02/06(THU) 07:35:00
-      .ChatMain__MessagesList__box__message
-        %p おはよう！6
-    .ChatMain__MessagesList__box
-      .ChatMain__MessagesList__box__group
-        .ChatMain__MessagesList__box__group--name
-          %p sawa
-        .ChatMain__MessagesList__box__group--date
-          %p 2020/02/06(THU) 07:35:00
-      .ChatMain__MessagesList__box__message
-        %p おはよう！7
+    .messages
+      = render @messages
   .ChatMain__MessageForm
     = form_for [@group, @message] do |f|
       .ChatMain__MessageForm__FormBox

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,12 @@
+.message
+  .ChatMain__MessagesList__box
+    .ChatMain__MessagesList__box__group
+      .ChatMain__MessagesList__box__group--name
+        = message.user.name
+      .ChatMain__MessagesList__box__group--date
+        = message.created_at.strftime("%Y年%m月%d日　%H時%M分")
+    .ChatMain__MessagesList__box__message
+      - if message.content.present?
+        %p.ChatMain__MessagesList__box__message__content
+          = message.content
+      = image_tag message.image.url, class: 'ChatMain__MessagesList__box__image' if message.image.present?

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -15,7 +15,7 @@
   .SideBar__GroupList
     - current_user.groups.each do |groupbox|
       .groupbox
-        = link_to '#' do
+        = link_to group_messages_path(groupbox) do
           .groupbox__GroupName
             = groupbox.name
           .groupbox__GroupMessage


### PR DESCRIPTION
## what
- グループのメッセージ内容を表示する
-- メインチャット画面のビューの実装
## why
- 送信したメッセージをグループ、ユーザと紐付けて表示させるため