### PR TITLE
自動更新機能実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -67,6 +67,82 @@ $(function(){
     .fail(function(){
       alert("メッセージ送信に失敗しました");
     })
-  });
+  })
+  
+  var buildHTML = function(message) {
+    var htmlbuild_name_data =`
+      <div class="ChatMain__MessagesList__box__group">
+        <div class="ChatMain__MessagesList__box__group--name">
+          ${message.user_name}
+        </div>
+        <div class="ChatMain__MessagesList__box__group--date">
+          ${message.created_at}
+        </div>
+      </div>`
+    var htmlbuild_content = `
+      <p class="ChatMain__MessagesList__box__message__content">
+        ${message.content}
+      </p>`
+    var htmlbuild_img =`<img src="${message.image}" class="ChatMain__MessagesList__box__image" >`
 
+    if (message.content && message.image) {
+      var html = `
+      <div class="message" data-message-id=${message.id}>
+        <div class="ChatMain__MessagesList__box">
+          ${htmlbuild_name_data}
+          <div class="ChatMain__MessagesList__box__message">
+            ${htmlbuild_content}
+            ${htmlbuild_img}
+          </div>
+        </div>
+      </div>`
+    } else if (message.content) {
+      var html = `
+      <div class="message" data-message-id=${message.id}>
+        <div class="ChatMain__MessagesList__box">
+          ${htmlbuild_name_data}
+          <div class="ChatMain__MessagesList__box__message">
+            ${htmlbuild_content}
+          </div>
+        </div>
+      </div>`
+    } else if (message.image) {
+      var html = `
+      <div class="message" data-message-id=${message.id}>
+        <div class="ChatMain__MessagesList__box">
+          ${htmlbuild_name_data}
+          <div class="ChatMain__MessagesList__box__message">
+            ${htmlbuild_img}
+          </div>
+        </div>
+      </div>`
+    };
+    return html;
+  };
+
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .ChatMain__MessagesList__box
     .ChatMain__MessagesList__box__group
       .ChatMain__MessagesList__box__group--name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日　%H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
## what
- チャット画面で自動更新機能実装
-- 表示されているメッセージのidが確認できる
-- 新規投稿を確認するアクションの実装（apiディレクトリ作成・コントローラ・名前空間を利用したルーティング）
-- 新規メッセージをメッセージ一覧の最後に追加し表示させる
-- 数秒ごとにリクエストするように実装
-- 新規メッセージを取得したら自動でスクロールする 

##why
- 非同期通信を実装したが、他のユーザ（ブラウザ）ではリロードしなければ投稿内容が更新されない為。
- リアルタイムでチャットできる機能を実装するため

Gyazo gif
↓
https://gyazo.com/00edd3beefa892751e2dab3661283137
